### PR TITLE
Update assembler

### DIFF
--- a/CommandInfo.cs
+++ b/CommandInfo.cs
@@ -4,12 +4,10 @@ namespace Emulator
 {
     public enum CommandArgumentType
     {
-        RegisterName,
-        Int8,
-        Int16,
-        LabelName,
-        RegisterPairName,
-        Address,
+        RegisterName = 0,
+        Int8 = 1,
+        Int16 = 2,
+        RegisterPairName = 4,
     }
 
     public class CommandInfo

--- a/CommandInfo.cs
+++ b/CommandInfo.cs
@@ -8,13 +8,16 @@ namespace Emulator
         Int8,
         Int16,
         LabelName,
+        RegisterPairName,
         Address,
     }
-    
+
     public class CommandInfo
     {
         public string OpCode = "0";
         public List<CommandArgumentType> Arguments = new List<CommandArgumentType>();
+
+        public Dictionary<int, int>? RegisterNameArgumentOffsets;
 
         /// <summary>
         /// User written note that explains what this command does

--- a/CommandInfo.cs
+++ b/CommandInfo.cs
@@ -7,8 +7,10 @@ namespace Emulator
         RegisterName,
         Int8,
         Int16,
-        LabelName
+        LabelName,
+        Address,
     }
+    
     public class CommandInfo
     {
         public string OpCode = "0";

--- a/Configuration/CommandInfo.json
+++ b/Configuration/CommandInfo.json
@@ -147,63 +147,63 @@
         },
         "call": {
             "Arguments": [
-                4
+                2
             ],
             "OpCode": "cd",
             "Note": "Calls a subroutine"
         },
         "cm": {
             "Arguments": [
-                4
+                2
             ],
             "OpCode": "fc",
             "Note": "Calls a subroutine if S flag is true"
         },
         "cpe": {
             "Arguments": [
-                4
+                2
             ],
             "OpCode": "ec",
             "Note": "Calls a subroutine if P flag is true"
         },
         "cc": {
             "Arguments": [
-                4
+                2
             ],
             "OpCode": "dc",
             "Note": "Calls a subroutine if C flag is true"
         },
         "cz": {
             "Arguments": [
-                4
+                2
             ],
             "OpCode": "cc",
             "Note": "Calls a subroutine if Z flag is true"
         },
         "cp": {
             "Arguments": [
-                4
+                2
             ],
             "OpCode": "f4",
             "Note": "Calls a subroutine if S flag is false"
         },
         "cpo": {
             "Arguments": [
-                4
+                2
             ],
             "OpCode": "e4",
             "Note": "Calls a subroutine if P flag is false"
         },
         "cnc": {
             "Arguments": [
-                4
+                2
             ],
             "OpCode": "d4",
             "Note": "Calls a subroutine if C flag is false"
         },
         "cnz": {
             "Arguments": [
-                4
+                2
             ],
             "OpCode": "c4",
             "Note": "Calls a subroutine if Z flag is false"
@@ -253,55 +253,55 @@
         },
         "jmp": {
             "Arguments": [
-                4
+                2
             ],
             "OpCode": "c3"
         },
         "jm": {
             "Arguments": [
-                4
+                2
             ],
             "OpCode": "fa"
         },
         "jpe": {
             "Arguments": [
-                4
+                2
             ],
             "OpCode": "ea"
         },
         "jc": {
             "Arguments": [
-                4
+                2
             ],
             "OpCode": "da"
         },
         "jz": {
             "Arguments": [
-                4
+                2
             ],
             "OpCode": "ca"
         },
         "jp": {
             "Arguments": [
-                4
+                2
             ],
             "OpCode": "f2"
         },
         "jpo": {
             "Arguments": [
-                4
+                2
             ],
             "OpCode": "e2"
         },
         "jnc": {
             "Arguments": [
-                4
+                2
             ],
             "OpCode": "d2"
         },
         "jnz": {
             "Arguments": [
-                4
+                2
             ],
             "OpCode": "c2"
         },

--- a/Configuration/CommandInfo.json
+++ b/Configuration/CommandInfo.json
@@ -28,7 +28,10 @@
                 0,
                 1
             ],
-            "OpCode": "0",
+            "RegisterNameArgumentOffsets" : {
+                "0" : 8
+            },
+            "OpCode": "0x06",
             "Note": "Writes a value into the register"
         },
         "mov": {
@@ -36,7 +39,11 @@
                 0,
                 0
             ],
-            "OpCode": "0",
+            "RegisterNameArgumentOffsets" : {
+                "0" : 8,
+                "1" : 1
+            },
+            "OpCode": "0x40",
             "Note": "Copies value from register on the left to register on the right"
         },
         "sta": {
@@ -57,14 +64,20 @@
             "Arguments": [
                 0
             ],
-            "OpCode": "0",
+            "OpCode": "0x80",
+            "RegisterNameArgumentOffsets" : {
+                "0" : 1
+            },
             "Note": "Adds value from register to accumulator"
         },
         "adc": {
             "Arguments": [
                 0
             ],
-            "OpCode": "0",
+            "OpCode": "0x88",
+            "RegisterNameArgumentOffsets" : {
+                "0" : 1
+            },
             "Note": "Adds value from register to accumulator with carry"
         },
         "adi": {
@@ -85,14 +98,20 @@
             "Arguments": [
                 0
             ],
-            "OpCode": 0,
+            "OpCode": "0x90",
+            "RegisterNameArgumentOffsets" : {
+                "0" : 1
+            },
             "Note": "Subtracts value in register from accumulator"
         },
         "sbb": {
             "Arguments": [
                 0
             ],
-            "OpCode": 0,
+            "OpCode": "0x98",
+            "RegisterNameArgumentOffsets" : {
+                "0" : 1
+            },
             "Note": "Subtracts value in register from accumulator with carry"
         },
         "sbi": {
@@ -120,7 +139,10 @@
             "Arguments": [
                 0
             ],
-            "OpCode": "0",
+            "OpCode": "0xb8",
+            "RegisterNameArgumentOffsets" : {
+                "0" : 1
+            },
             "Note": "Compares accumulator with register"
         },
         "call": {
@@ -297,22 +319,31 @@
         },
         "push": {
             "Arguments": [
-                0
+                4
             ],
-            "OpCode": "0"
+            "OpCode": "0xc5",
+            "RegisterNameArgumentOffsets" : {
+                "0" : 16
+            }
         },
         "pop": {
             "Arguments": [
-                0
+                4
             ],
-            "OpCode": "0"
+            "OpCode": "0xc1",
+            "RegisterNameArgumentOffsets" : {
+                "0" : 16
+            }
         },
         "lxi": {
             "Arguments": [
-                0,
+                4,
                 2
             ],
-            "OpCode": "0"
+            "OpCode": "0x01",
+            "RegisterNameArgumentOffsets" : {
+                "0" : 16
+            }
         },
         "ani": {
             "Arguments": [
@@ -324,7 +355,10 @@
             "Arguments": [
                 0
             ],
-            "OpCode": "0"
+            "OpCode": "0xa0",
+            "RegisterNameArgumentOffsets" : {
+                "0" : 1
+            }
         },
         "ori": {
             "Arguments": [
@@ -336,7 +370,10 @@
             "Arguments": [
                 0
             ],
-            "OpCode": "0"
+            "OpCode": "0xb0",
+            "RegisterNameArgumentOffsets" : {
+                "0" : 1
+            }
         },
         "xri": {
             "Arguments": [
@@ -348,7 +385,10 @@
             "Arguments": [
                 0
             ],
-            "OpCode": "0"
+            "OpCode": "0xa8",
+            "RegisterNameArgumentOffsets" : {
+                "0" : 1
+            }
         },
         "ral": {
             "Arguments": [],
@@ -370,25 +410,37 @@
             "Arguments": [
                 0
             ],
-            "OpCode": "0"
+            "OpCode": "0x04",
+            "RegisterNameArgumentOffsets" : {
+                "0" : 8
+            }
         },
         "dcr": {
             "Arguments": [
                 0
             ],
-            "OpCode": "0"
+            "OpCode": "0x05",
+            "RegisterNameArgumentOffsets" : {
+                "0" : 8
+            }
         },
         "inx": {
             "Arguments": [
-                0
+                4
             ],
-            "OpCode": "0"
+            "OpCode": "0x03",
+            "RegisterNameArgumentOffsets" : {
+                "0" : 16
+            }
         },
         "dcx": {
             "Arguments": [
-                0
+                4
             ],
-            "OpCode": "0"
+            "OpCode": "0x0b",
+            "RegisterNameArgumentOffsets" : {
+                "0" : 16
+            }
         },
         "stax": {
             "Arguments": [
@@ -416,9 +468,12 @@
         },
         "dad": {
             "Arguments": [
-                0
+                4
             ],
-            "OpCode": "0"
+            "OpCode": "0x09",
+            "RegisterNameArgumentOffsets" : {
+                "0" : 16
+            }
         },
         "xthl": {
             "OpCode": "e3"

--- a/Converter.cs
+++ b/Converter.cs
@@ -4,6 +4,8 @@ using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using System;
 using System.Linq;
+using Newtonsoft.Json;
+
 namespace Emulator
 {
     /// <summary>
@@ -52,7 +54,7 @@ namespace Emulator
         }
     }
 
-    public static class Converter
+    public class Converter
     {
 
         private static List<string> _registerNames = new List<string> { "b", "c", "d", "e", "h", "l", "m", "a" };
@@ -63,24 +65,52 @@ namespace Emulator
         public static Regex ShortNumberRegex = new Regex(@"^(0x((\d|[A-F]){1,4}))|(\d{1,5})$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         public static Regex LabelRegex = new Regex(@"([A-z]|\d)+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
+        public Converter(string code, MemorySegmentationData memory)
+        {
+            _code = code;
+            _memory = memory;
+            _result = new ProcessedCodeInfo();
+            string infoText = System.IO.File.ReadAllText("./Configuration/CommandInfo.json");
+            _info = JsonConvert.DeserializeObject<ProcessorCommandsInfo>(infoText) ?? throw new NullReferenceException("Unable to process configuration");
+            _success = _prepare();
+        }
+
+        private MemorySegmentationData _memory;
+        private string _code;
+        private ProcessorCommandsInfo _info;
+        private ProcessedCodeInfo _result;
+        private bool _success = false;
+        //jumps that were referred to by call/jump commands
+        //used for checking if jump destination is valid at assemble time
+        private Dictionary<int, string> _referredJumps = new Dictionary<int, string>();
+        private Dictionary<int, int> _referredAddresses = new Dictionary<int, int>();
+        //Key is jump label, value is where to place address of the jump label
+        private Dictionary<int, string> _jumps = new Dictionary<int, string>();
+        //List of all user defined assemble time constants. They function similarly to #define in c++
+        private Dictionary<string, string> _defines = new Dictionary<string, string>();
+
+        public ProcessedCodeInfo? Result => _success ? _result : null;
+        public Dictionary<int, string> Errors => _result.Errors;
+        public bool Success => _success;
+
         /// <summary>
         /// Checks if given collection of regex matches is a valid operation
         /// </summary>
         /// <param name="input">Collection of reg ex matches that should contain [OPNAME], [Arg1] ...[ArgN]</param>
-        /// <param name="info">Processor commands info config that has information about commands</param>
+        /// <param name="_info">Processor commands info config that has information about commands</param>
         /// <returns>Null if no errors were found, or error message</returns>
-        private static string? _checkInputValidity(MatchCollection input, ProcessorCommandsInfo info, MemorySegmentationData memory)
+        private string? _checkInputValidity(MatchCollection input)
         {
-            if (info.Commands.ContainsKey(input[0].Value))
+            if (_info.Commands.ContainsKey(input[0].Value))
             {
-                int argumentCount = info.Commands[input[0].Value].Arguments.Count;
+                int argumentCount = _info.Commands[input[0].Value].Arguments.Count;
                 if (argumentCount != input.Count - 1)
                 {
                     return $"Operation expected {argumentCount} found {input.Count - 1}";
                 }
                 for (int i = 1; i < input.Count; i++)
                 {
-                    switch (info.Commands[input[0].Value].Arguments[i - 1])
+                    switch (_info.Commands[input[0].Value].Arguments[i - 1])
                     {
                         case CommandArgumentType.RegisterName:
                             if (!Regex.IsMatch(input[i].Value, "[A-z]"))
@@ -109,31 +139,178 @@ namespace Emulator
             }
             return null;
         }
+
+
+        private void _processDb(int lineId, MatchCollection matches)
+        {
+            foreach (Match match in matches.Skip(1))
+            {
+                try
+                {
+                    if (Regex.IsMatch(match.Value, @"(0x((\d|[A-F])(\d|[A-F])?))"))
+                    {
+                        _result.CommandBytes.Add(Convert.ToByte(match.Value, 16));//write the argument
+                    }
+                    else
+                    {
+                        _result.CommandBytes.Add(Convert.ToByte(match.Value));//write the argument
+                    }
+                }
+                catch (OverflowException e)
+                {
+                    _result.Errors.Add(lineId, "Expected 8bit number got 16bit or more");
+                }
+            }
+        }
+
+        private void _processDs(int lineId, MatchCollection matches)
+        {
+            if (matches.Count != 3)
+            {
+                _result.Errors.Add(lineId, "Pseudo operation db needs string and address");
+                lineId++;
+                return;
+            }
+            string clearValue = matches[1].Value.Replace("'", string.Empty);
+            int destination = 0x4000;
+            try
+            {
+                destination = Convert.ToUInt16(matches[2].Value, 16);
+            }
+            catch (OverflowException e)
+            {
+                _result.Errors.Add(lineId, "Expected 16bit address for string literal destination");
+            }
+
+            lineId++;
+            _result.StringLiterals.Add(destination, clearValue);
+        }
+
+        private void _addByteToResult(int lineId, string value)
+        {
+            try
+            {
+                if (Regex.IsMatch(value, @"(0x((\d|[A-F])(\d|[A-F])?))"))
+                {
+                    _result.CommandBytes.Add(Convert.ToByte(value, 16));//write the argument
+                }
+                else
+                {
+                    _result.CommandBytes.Add(Convert.ToByte(value));//write the argument
+                }
+            }
+            catch (OverflowException e)
+            {
+                _result.Errors.Add(lineId, "Expected 8bit number got 16bit or more");
+            }
+        }
+
+        private void _addShortToResult(int lineId, string value)
+        {
+            if (ShortNumberRegex.IsMatch(value))
+            {
+                try
+                {
+                    ushort val;
+                    if (Regex.IsMatch(value, @"(0x((\d|[A-F]){1,4}))"))
+                    {
+                        //First store argument's L then H 
+                        val = Convert.ToUInt16(value, 16);
+
+                    }
+                    else
+                    {
+                        val = Convert.ToUInt16(value);
+                    }
+                    _result.CommandBytes.Add((byte)(val & 0xff));
+                    _result.CommandBytes.Add((byte)((val & 0xff00) >> 8));
+                }
+                catch (OverflowException e)
+                {
+                    _result.Errors.Add(lineId, "Expected 16bit number got larger");
+                }
+                return;
+            }
+            if (LabelRegex.IsMatch(value))
+            {
+                _referredJumps.Add(lineId, value);
+                _jumps.Add(_result.CommandBytes.Count, value);
+                _result.CommandBytes.Add(0);
+                _result.CommandBytes.Add(0);
+                return;
+            }
+        }
+
+        private void _applyJumps()
+        {
+            foreach (var jump in _referredJumps)
+            {
+                if (!_result.JumpDestinations.ContainsKey(jump.Value))
+                {
+                    _result.Errors.Add(jump.Key, $"Invalid jump destination. No label \"{jump.Value}\" is present in the code");
+                }
+            }
+
+            foreach (var jump in _jumps)
+            {
+                if (!_result.JumpDestinations.ContainsKey(jump.Value))
+                {
+                    continue;
+                }
+                ushort dest = (ushort)_result.JumpDestinations[jump.Value];
+                _result.CommandBytes[jump.Key] = (byte)(dest & 0xff);
+                _result.CommandBytes[jump.Key + 1] = (byte)((dest & 0xff00) >> 8);
+            }
+        }
+
+        private void _applyAddresses()
+        {
+            foreach (var addresses in _referredAddresses)
+            {
+                if (addresses.Value < _memory.RomSize)
+                {
+                    _result.Errors.Add(addresses.Key, $"Illegal write address.  0000 to {(_memory.RomSize).ToString("X4")} is READ only memory");
+                }
+#if FORBID_WRITES_OUTSIDE_RAM
+                else if (addresses.Value < memory.RamStart || addresses.Value > memory.RamEnd)
+                {
+                    _result.Errors.Add(addresses.Key, $"Illegal write address.  Only writes to RAM ({memory.RamStart} to {memory.RamEnd}");
+                }
+#endif
+            }
+        }
+
+        private void _applyStringLiterals()
+        {
+            if (_result.StringLiterals.Count > 0)
+            {
+                int furthestStringAddress = _result.StringLiterals.Keys.Max() + _result.StringLiterals[_result.StringLiterals.Keys.Max()].Length + 1;
+                _result.CommandBytes.AddRange(new byte[furthestStringAddress - _result.CommandBytes.Count]);
+                foreach ((int addr, string value) in _result.StringLiterals)
+                {
+                    ushort currentAddress = (ushort)addr;
+                    for (int i = 0; i < value.Length; i++)
+                    {
+                        _result.CommandBytes[currentAddress++] = ((byte)value[i]);
+                    }
+                    _result.CommandBytes[currentAddress] = 0;
+                }
+            }
+        }
+
         /// <summary>
         /// Converts input code into operations
         /// </summary>
-        /// <param name="code"></param>
-        public static ProcessedCodeInfo Prepare(string code, MemorySegmentationData memory)
+        /// <param name="_code"></param>
+        private bool _prepare()
         {
-            string infoText = System.IO.File.ReadAllText("./Configuration/CommandInfo.json");
-            ProcessorCommandsInfo info = Newtonsoft.Json.JsonConvert.DeserializeObject<ProcessorCommandsInfo>(infoText) ?? throw new NullReferenceException("Unable to process configuration");
-
-            ProcessedCodeInfo result = new ProcessedCodeInfo();
-            //jumps that were referred to by call/jump commands
-            //used for checking if jump destination is valid at assemble time
-            Dictionary<int, string> referredJumps = new Dictionary<int, string>();
-            Dictionary<int, int> referredAddresses = new Dictionary<int, int>();
-            //Key is jump label, value is where to place address of the jump label
-            Dictionary<int, string> jumps = new Dictionary<int, string>();
-            //List of all user defined assemble time constants. They function similarly to #define in c++
-            Dictionary<string, string> defines = new Dictionary<string, string>();
             int lineId = 0;
             int address = 0;
-            string[] lines = code.Split("\n");
+            string[] lines = _code.Split("\n");
             foreach (string line in lines)
             {
                 string cleanLine = CommentRegex.Replace(line, "");
-                foreach (var define in defines)
+                foreach (var define in _defines)
                 {
                     cleanLine = Regex.Replace(cleanLine, $@"{define.Key}\b", define.Value);
                 }
@@ -145,14 +322,14 @@ namespace Emulator
                 }
                 if (LabelDefinitionRegex.IsMatch(cleanLine))
                 {
-                    result.JumpDestinations.Add(LabelDefinitionRegex.Match(cleanLine).Value, result.CommandBytes.Count);
+                    _result.JumpDestinations.Add(LabelDefinitionRegex.Match(cleanLine).Value, _result.CommandBytes.Count);
                     lineId++;
                     continue;
                 }
                 MatchCollection matches = OperationSeparator.Matches(cleanLine);
                 if (matches.Count == 0)
                 {
-                    result.Errors.Add(lineId, "Line contains no valid assembly code");
+                    _result.Errors.Add(lineId, "Line contains no valid assembly code");
                     lineId++;
                     continue;
                 }
@@ -161,233 +338,102 @@ namespace Emulator
                 {
                     if (matches.Count != 3)
                     {
-                        result.Errors.Add(lineId, "Pseudo operation set needs define name and value");
+                        _result.Errors.Add(lineId, "Pseudo operation set needs define name and value");
                         lineId++;
                         continue;
                     }
                     string clearValue = matches[2].Value.Replace("'", string.Empty);
-                    defines.Add(matches[1].Value, clearValue);
+                    _defines.Add(matches[1].Value, clearValue);
                     lineId++;
                     continue;
                 }
                 if (name == "ds")
                 {
-                    if (matches.Count != 3)
-                    {
-                        result.Errors.Add(lineId, "Pseudo operation db needs string and address");
-                        lineId++;
-                        continue;
-                    }
-                    string clearValue = matches[1].Value.Replace("'", string.Empty);
-                    int destination = 0x4000;
-                    try
-                    {
-                        destination = Convert.ToUInt16(matches[2].Value, 16);
-                    }
-                    catch (OverflowException e)
-                    {
-                        result.Errors.Add(lineId, "Expected 16bit address for string literal destination");
-                    }
-
-                    lineId++;
-                    result.StringLiterals.Add(destination, clearValue);
+                    _processDs(lineId, matches);
                     continue;
                 }
                 if (name == "db")
                 {
-                    foreach (Match match in matches.Skip(1))
-                    {
-                        try
-                        {
-                            if (Regex.IsMatch(match.Value, @"(0x((\d|[A-F])(\d|[A-F])?))"))
-                            {
-                                result.CommandBytes.Add(Convert.ToByte(match.Value, 16));//write the argument
-                            }
-                            else
-                            {
-                                result.CommandBytes.Add(Convert.ToByte(match.Value));//write the argument
-                            }
-                        }
-                        catch (OverflowException e)
-                        {
-                            result.Errors.Add(lineId, "Expected 8bit number got 16bit or more");
-                        }
-                    }
+                    _processDb(lineId, matches);
                     continue;
                 }
-                string? error = _checkInputValidity(matches, info, memory);
+                string? error = _checkInputValidity(matches);
                 if (error != null)
                 {
-                    result.Errors.Add(lineId, error);
+                    _result.Errors.Add(lineId, error);
                     lineId++;
                     continue;
                 }
-                if (info.StaticAddressCommands.Contains(name))
+                if (_info.StaticAddressCommands.Contains(name))
                 {
-                    referredAddresses.Add(lineId, Convert.ToUInt16(matches[1].Value, 16));
+                    _referredAddresses.Add(lineId, Convert.ToUInt16(matches[1].Value, 16));
                 }
-                // handle commands that use different opcodes for combinations of registers
-                switch (name)
+                //handle stax and ldax separetely cause they are only two commands that share this special argument type
+                if (name == "ldax")
                 {
-                    case "ldax":
-                        switch (matches[1].Value)
-                        {
-                            case "b":
-                                result.CommandBytes.Add(0x0A);
-                                break;
-                            case "d":
-                                result.CommandBytes.Add(0x1A);
-                                break;
-                        }
-                        break;
-                    case "stax":
-                        switch (matches[1].Value)
-                        {
-                            case "b":
-                                result.CommandBytes.Add(0x02);
-                                break;
-                            case "d":
-                                result.CommandBytes.Add(0x12);
-                                break;
-                        }
-                        break;
-                    //Every other operation will just have it's byte written down and arguments written out 
-                    default:
-                        {
-                            CommandInfo op = info.Commands[name];
-                            int opCode = Convert.ToByte(op.OpCode, 16);
-                            int commandLocation = result.CommandBytes.Count;
-                            result.CommandBytes.Add((byte)opCode);
-                            for (int i = 1; i < matches.Count; i++)
-                            {
-                                switch (op.Arguments[i - 1])
-                                {
-                                    case CommandArgumentType.RegisterName:
-                                        {
-                                            opCode += _registerNames.IndexOf(matches[i].Value.ToLower()) * (op?.RegisterNameArgumentOffsets[i - 1] ?? 0);
-                                            result.CommandBytes[commandLocation] = (byte)opCode;
-                                        }
-                                        break;
-                                    case CommandArgumentType.RegisterPairName:
-                                        {
-                                            int id = _registerPairNames.IndexOf(matches[i].Value.ToLower());
-                                            opCode += (id < 0 ? _registerPairNames.Count : id) * (op?.RegisterNameArgumentOffsets[i - 1] ?? 0);
-                                            result.CommandBytes[commandLocation] = (byte)opCode;
-                                        }
-                                        break;
-                                    case CommandArgumentType.Int8:
-                                        try
-                                        {
-                                            if (Regex.IsMatch(matches[i].Value, @"(0x((\d|[A-F])(\d|[A-F])?))"))
-                                            {
-                                                result.CommandBytes.Add(Convert.ToByte(matches[i].Value, 16));//write the argument
-                                            }
-                                            else
-                                            {
-                                                result.CommandBytes.Add(Convert.ToByte(matches[i].Value));//write the argument
-                                            }
-                                        }
-                                        catch (OverflowException e)
-                                        {
-                                            result.Errors.Add(lineId, "Expected 8bit number got 16bit or more");
-                                        }
-                                        break;
-                                    case CommandArgumentType.Int16:
-                                        if (ShortNumberRegex.IsMatch(matches[i].Value))
-                                        {
-                                            try
-                                            {
-                                                ushort val;
-                                                if (Regex.IsMatch(matches[i].Value, @"(0x((\d|[A-F]){1,4}))"))
-                                                {
-                                                    //First store argument's L then H 
-                                                    val = Convert.ToUInt16(matches[i].Value, 16);
-
-                                                }
-                                                else
-                                                {
-                                                    val = Convert.ToUInt16(matches[i].Value);
-                                                }
-                                                result.CommandBytes.Add((byte)(val & 0xff));
-                                                result.CommandBytes.Add((byte)((val & 0xff00) >> 8));
-                                            }
-                                            catch (OverflowException e)
-                                            {
-                                                result.Errors.Add(lineId, "Expected 16bit number got larger");
-                                            }
-                                            break;
-                                        }
-                                        if (LabelRegex.IsMatch(matches[i].Value))
-                                        {
-                                            referredJumps.Add(lineId, matches[i].Value);
-                                            jumps.Add(result.CommandBytes.Count, matches[i].Value);
-                                            result.CommandBytes.Add(0);
-                                            result.CommandBytes.Add(0);
-                                            break;
-                                        }
-                                        break;
-                                }
-                            }
-                        }/*
-                        if (info.JumpCommands.Contains(name))
-                        {
-                            referredJumps.Add(lineId, matches[1].Value);
-                            jumps.Add(result.CommandBytes.Count, matches[1].Value);
-                            result.CommandBytes.Add(0);
-                            result.CommandBytes.Add(0);
-                        }*/
-                        break;
-                }
-                address += info.Commands[name].Arguments.Count + 1;
-                result.Length += info.Commands[name].Arguments.Count + 1;
-                lineId++;
-            }
-            foreach (var jump in referredJumps)
-            {
-                if (!result.JumpDestinations.ContainsKey(jump.Value))
-                {
-                    result.Errors.Add(jump.Key, $"Invalid jump destination. No label \"{jump.Value}\" is present in the code");
-                }
-            }
-            foreach (var addresses in referredAddresses)
-            {
-                if (addresses.Value < memory.RomSize)
-                {
-                    result.Errors.Add(addresses.Key, $"Illegal write address.  0000 to {(memory.RomSize).ToString("X4")} is READ only memory");
-                }
-#if FORBID_WRITES_OUTSIDE_RAM
-                else if (addresses.Value < memory.RamStart || addresses.Value > memory.RamEnd)
-                {
-                    result.Errors.Add(addresses.Key, $"Illegal write address.  Only writes to RAM ({memory.RamStart} to {memory.RamEnd}");
-                }
-#endif
-            }
-            foreach (var jump in jumps)
-            {
-                if (!result.JumpDestinations.ContainsKey(jump.Value))
-                {
+                    switch (matches[1].Value)
+                    {
+                        case "b":
+                            _result.CommandBytes.Add(0x0A);
+                            break;
+                        case "d":
+                            _result.CommandBytes.Add(0x1A);
+                            break;
+                    }
                     continue;
                 }
-                ushort dest = (ushort)result.JumpDestinations[jump.Value];
-                result.CommandBytes[jump.Key] = (byte)(dest & 0xff);
-                result.CommandBytes[jump.Key + 1] = (byte)((dest & 0xff00) >> 8);
-            }
-            if (result.StringLiterals.Count > 0)
-            {
-                int furthestStringAddress = result.StringLiterals.Keys.Max() + result.StringLiterals[result.StringLiterals.Keys.Max()].Length + 1;
-                result.CommandBytes.AddRange(new byte[furthestStringAddress - result.CommandBytes.Count]);
-                foreach ((int addr, string value) in result.StringLiterals)
+                else if (name == "stax")
                 {
-                    ushort currentAddress = (ushort)addr;
-                    for (int i = 0; i < value.Length; i++)
+                    switch (matches[1].Value)
                     {
-                        result.CommandBytes[currentAddress++] = ((byte)value[i]);
+                        case "b":
+                            _result.CommandBytes.Add(0x02);
+                            break;
+                        case "d":
+                            _result.CommandBytes.Add(0x12);
+                            break;
                     }
-                    result.CommandBytes[currentAddress] = 0;
+                    continue;
                 }
+                CommandInfo op = _info.Commands[name];
+                int opCode = Convert.ToByte(op.OpCode, 16);
+                int commandLocation = _result.CommandBytes.Count;
+                _result.CommandBytes.Add((byte)opCode);
+                for (int i = 1; i < matches.Count; i++)
+                {
+                    switch (op.Arguments[i - 1])
+                    {
+                        case CommandArgumentType.RegisterName:
+                            {
+                                opCode += _registerNames.IndexOf(matches[i].Value.ToLower()) * (op?.RegisterNameArgumentOffsets[i - 1] ?? 0);
+                                _result.CommandBytes[commandLocation] = (byte)opCode;
+                            }
+                            break;
+                        case CommandArgumentType.RegisterPairName:
+                            {
+                                int id = _registerPairNames.IndexOf(matches[i].Value.ToLower());
+                                opCode += (id < 0 ? _registerPairNames.Count : id) * (op?.RegisterNameArgumentOffsets[i - 1] ?? 0);
+                                _result.CommandBytes[commandLocation] = (byte)opCode;
+                            }
+                            break;
+                        case CommandArgumentType.Int8:
+                            _addByteToResult(lineId, matches[i].Value);
+                            break;
+                        case CommandArgumentType.Int16:
+                            _addShortToResult(lineId, matches[i].Value);
+                            break;
+                    }
+                }
+                address += _info.Commands[name].Arguments.Count + 1;
+                _result.Length += _info.Commands[name].Arguments.Count + 1;
+                lineId++;
             }
-            result.Success = result.Errors.Count == 0;
-            return result;
+            _applyJumps();
+            _applyAddresses();
+            _applyStringLiterals();
+
+            _result.Success = _result.Errors.Count == 0;
+            return _result.Success;
         }
     }
 }

--- a/HelpWindow.axaml.cs
+++ b/HelpWindow.axaml.cs
@@ -57,10 +57,7 @@ namespace Nema
                             arguments += "D8";
                             break;
                         case CommandArgumentType.Int16:
-                            arguments += "D16";
-                            break;
-                        case CommandArgumentType.LabelName:
-                            arguments += "Label";
+                            arguments += "Label/D16";
                             break;
                     }
                     arguments += ",";

--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -273,10 +273,16 @@ namespace Nema
         {
             if (!string.IsNullOrWhiteSpace(CodeInputBox.Text))
             {
-                Emulator.ProcessedCodeInfo code = Emulator.Converter.Prepare(CodeInputBox.Text, _emulator.Memory.MemoryData);
-                _recordErrors(code.Errors);
-                _emulator.SetCode(code);
-                _emulator.ResetProcessor();
+                Emulator.Converter converter = new Emulator.Converter(CodeInputBox.Text, _emulator.Memory.MemoryData);
+                if (converter.Success)
+                {
+                    _emulator.SetCode(converter.Result);
+                    _emulator.ResetProcessor();
+                }
+                else
+                {
+                    _recordErrors(converter.Errors);
+                }
             }
         }
 


### PR DESCRIPTION
Removes a lot of hard coded repetitions for commands that use register names or register pair names by adding a new value to  config
Updates  labels to function much  closer to their counterpart in  modern assembly. This allows  to
*  Have hard-coded values in jump and call instructions, instead of always using labels
*  Have numbers in the label names

Immediate number system  was also updated, instead of treating every number as hex value, now hex values are prefixed with `0x`. Negative numbers are not permitted and will be treated as if minus is not present.

All of the byte code produced with updated assembler is compatible with previous iteration